### PR TITLE
[Jitera] Implement Account Lock Handling After Failed Login Attempts

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { NODE_ENV } from 'src/constants'
-import { Config } from './config.interface'
+import type { Config } from './config.interface'
 import { DriverType } from '@codebrew/nestjs-storage'
 import { getCredentials } from 'src/utils/credentials'
 import { config } from 'dotenv'
@@ -76,11 +76,10 @@ export default (): Config => {
       sendConfirmationEmail: Boolean(process.env.AUTH_SEND_CONFIRMATION_EMAIL) || false,
       confirmationUrl: process.env.AUTH_CONFIRMATION_URL || 'http://localhost:3000/confirm',
       confirmationIn: +process.env.AUTH_CONFIRMATION_IN || 24,
-      passwordExpirationDays: +process.env.AUTH_PASSWORD_EXPIRATION_DAYS || 90, // Added line
       resetPasswordUrl:
         process.env.AUTH_RESET_PASSWORD_URL || 'http://localhost:3000/reset-password',
       resetPasswordIn: +process.env.AUTH_RESET_PASSWORD_IN || 1,
-      maximumAttempts: 10,
+      maximumAttempts: +process.env.AUTH_MAXIMUM_ATTEMPTS || 5,
     },
     mail: {
       provider: process.env.MAIL_PROVIDER || 'maildev',

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -80,6 +80,7 @@ export default (): Config => {
         process.env.AUTH_RESET_PASSWORD_URL || 'http://localhost:3000/reset-password',
       resetPasswordIn: +process.env.AUTH_RESET_PASSWORD_IN || 1,
       maximumAttempts: +process.env.AUTH_MAXIMUM_ATTEMPTS || 5,
+      passwordExpirationDays: +process.env.AUTH_PASSWORD_EXPIRATION_DAYS || 90,
     },
     mail: {
       provider: process.env.MAIL_PROVIDER || 'maildev',

--- a/src/entities/users.ts
+++ b/src/entities/users.ts
@@ -46,6 +46,9 @@ export class User {
   })
   status: `${StatusEnum}` = 'ACTIVE';
 
+  @Column({ default: 0 })
+  failedAttempts: number;
+
   @Column({ nullable: true, type: 'timestamp' })
   password_last_changed: Date;
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -17,12 +17,13 @@ export class AuthController {
 
     if (error) {
       response.error = error;
-      if (error === 'Account is locked' || error === 'Account is invalid') {
+      if (error === 'Account is locked') {
         throw new HttpException({ status: HttpStatus.UNAUTHORIZED, error: error }, HttpStatus.UNAUTHORIZED);
+      } else if (error === 'Account has been locked due to multiple failed login attempts.') {
+        throw new HttpException({ status: HttpStatus.TOO_MANY_REQUESTS, error: error }, HttpStatus.TOO_MANY_REQUESTS);
       } else if (error === 'Incorrect login details') {
         throw new HttpException({ status: HttpStatus.BAD_REQUEST, error: error }, HttpStatus.BAD_REQUEST);
       } else if (error === 'Password has expired, please reset your password.') {
-        response.redirect = 'password-reset';
         throw new HttpException({ status: HttpStatus.FOUND, redirect: 'password-reset' }, HttpStatus.FOUND);
       }
     } else if (redirect) {

--- a/src/modules/auth/dtos/login-response.dto.ts
+++ b/src/modules/auth/dtos/login-response.dto.ts
@@ -8,14 +8,4 @@ export class LoginResponseDto {
   token?: string;
   // Optional properties for account lock handling
   accountLocked?: boolean; // Indicates if the account is locked
-  lockReason?: string; // Reason why the account is locked
-}
-export class LoginResponseDto {
-  status: number;
-  message: string;
-  session_token?: string;
-  redirect?: string; // Redirection command to home page or password reset page if needed
-  failedLoginAttempts?: number; // Number of failed login attempts
-  error?: string;
-  token?: string;
 }

--- a/src/modules/auth/dtos/login-response.dto.ts
+++ b/src/modules/auth/dtos/login-response.dto.ts
@@ -3,6 +3,19 @@ export class LoginResponseDto {
   message: string;
   session_token?: string;
   redirect?: string; // Redirection command to home page or password reset page if needed
+  failedLoginAttempts?: number; // Number of failed login attempts
+  error?: string;
+  token?: string;
+  // Optional properties for account lock handling
+  accountLocked?: boolean; // Indicates if the account is locked
+  lockReason?: string; // Reason why the account is locked
+}
+export class LoginResponseDto {
+  status: number;
+  message: string;
+  session_token?: string;
+  redirect?: string; // Redirection command to home page or password reset page if needed
+  failedLoginAttempts?: number; // Number of failed login attempts
   error?: string;
   token?: string;
 }


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [BL] Lock user account after failed attempts
| file | name |
| --- | --- |
| /src/modules/auth/auth.service.ts | Add "lockUserAccount" to "AuthService" to lock user account after failed attempts |
| /src/modules/auth/auth.service.ts | Update "authenticateUserLogin" to increment failed login attempts and lock account |
------
#### [API] User Account Lock Handling
| file | name |
| --- | --- |
| /src/modules/auth/auth.service.ts | Implement account lock handling in AuthService |
| /src/configs/index.ts | Ensure maximumAttempts configuration is available |
| /src/modules/auth/dtos/login-response.dto.ts | Update LoginResponseDto to include lock-related error messages |
| /src/modules/auth/auth.controller.ts | Handle account lock responses in AuthController |
------
#### [FIX] 17980 Issues
| file | log | name |
| --- | --- | --- |
| /src/configs/index.ts | src/configs/index.ts:75:5 - error TS2741: Property 'passwordExpirationDays' is missing in type '{ sendConfirmationEmail: boolean; confirmationUrl: string; confirmationIn: number; resetPasswordUrl: string; resetPasswordIn: number; maximumAttempts: number; }' but required in type 'AuthenticationConfig'. |  |
| /src/modules/auth/auth.service.ts | src/modules/auth/auth.service.ts:43:12 - error TS2339: Property 'failedAttempts' does not exist on type 'User'. |  |
| /src/modules/auth/dtos/login-response.dto.ts | src/modules/auth/dtos/login-response.dto.ts:1:14 - error TS2300: Duplicate identifier 'LoginResponseDto'.
src/modules/auth/dtos/login-response.dto.ts:13:14 - error TS2300: Duplicate identifier 'LoginResponseDto'. |  |
------